### PR TITLE
use explode instead of split

### DIFF
--- a/mysql-revisioning.php
+++ b/mysql-revisioning.php
@@ -636,7 +636,7 @@ MESSAGE;
 				
 		for ($i=1; $i < $_SERVER['argc']; $i++) {
 			if (strncmp($_SERVER['argv'][$i], '--', 2) == 0) {
-				list($key, $value) = split("=", substr($_SERVER['argv'][$i], 2), 2) + array(1=>null);
+				list($key, $value) = explode("=", substr($_SERVER['argv'][$i], 2), 2) + array(1=>null);
 				
 				if (property_exists($this, $key)) $this->$key = isset($value) ? $value : true;
 				  elseif (!isset($value)) $cmd = $key;


### PR DESCRIPTION
split() is deprecated as of PHP 5.3.0.