### PR TITLE
use SIGNAL SQLSTATE

### DIFF
--- a/mysql-revisioning.php
+++ b/mysql-revisioning.php
@@ -32,7 +32,7 @@ class MySQL_Revisioning
 	public function connect($conn)
 	{
 		$this->conn = $conn instanceof mysqli ? $conn : new mysqli($conn['host'], $conn['user'], $conn['password'], $conn['db']);
-		if (!isset($this->signal)) $this->signal = $this->conn->server_version >= 60000 ? 'SIGNAL %errno SET MESSAGE_TEXT="%errmsg"' : 'DO `%errmsg`';
+		if (!isset($this->signal)) $this->signal = $this->conn->server_version >= 60000 ? 'SIGNAL SQLSTATE \'%errno\' SET MESSAGE_TEXT="%errmsg"' : 'DO `%errmsg`';
 	}
 	
 	/**


### PR DESCRIPTION
to avoid `PHP Fatal error:  Uncaught exception 'Exception' with message 'Query failed (1064): You have an error in your SQL syntax;`
